### PR TITLE
Fix .bashrc in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,7 @@ RUN curl -OL https://github.com/gohugoio/hugo/releases/download/v${VERSION_HUGO}
     rm -rf hugo_${VERSION_HUGO}_Linux-64bit.tar.gz
 
 # Configure environment
-RUN echo export PATH="\
-    /root/.nvm/versions/node/${VERSION_NODE}/bin:\
-    $PATH" >> ~/.bashrc && \
+RUN echo export PATH="/root/.nvm/versions/node/${VERSION_NODE}/bin:\$PATH" >> ~/.bashrc && \
     echo "nvm use ${VERSION_NODE} 1> /dev/null" >> ~/.bashrc
 
 ENTRYPOINT [ "bash", "-c" ]


### PR DESCRIPTION
Spaces in docker file will set incorrect `$PATH`
e.g.
```
Step 7/8 : RUN echo export PATH="    /root/.nvm/versions/node/${VERSION_NODE}/bin:    $PATH" >> ~/.bashrc &&     echo "nvm use ${VERSION_NODE} 1> /dev/null" >> ~/.bashrc
```
Causes
```
bash: export: `/root/.nvm/versions/node/14.17.0/bin:': not a valid identifier
bash: export: `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin': not a valid identifier
bash: tr: No such file or directory
bash: tr: No such file or directory
bash: tail: No such file or directory
bash: sed: No such file or directory
bash: ls: No such file or directory
bash: grep: No such file or directory
bash: grep: No such file or directory
bash: ls: No such file or directory
N/A: version "14.17.0 -> N/A" is not yet installed.
```